### PR TITLE
Try to avoid messing with Mason's `compile` interface

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8.0-rc1'
+          - '1.8.0-beta3'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         version:
           - '1.7'
-          - '1.8.0-rc1'
+          - '1.8.0-beta3'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaticCompiler"
 uuid = "81625895-6c0f-48fc-b932-11a18313743c"
-authors = ["Tom Short"]
-version = "0.4.5"
+authors = ["Tom Short and contributors"]
+version = "0.4.6"
 
 [deps]
 Clang_jll = "0ee61d77-7f21-5576-8119-9fcc46b10100"

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -89,7 +89,7 @@ single method (the method determined by `types`).
 function compile(f, _tt, path::String = tempname();  name = GPUCompiler.safe_name(repr(f)), filename="obj",
                  strip_llvm = false,
                  strip_asm  = true,
-                 opt_level=3,
+                 opt_level = 3,
                  kwargs...)
     tt = Base.to_tuple_type(_tt)
     isconcretetype(tt) || error("input type signature $_tt is not concrete")
@@ -98,13 +98,8 @@ function compile(f, _tt, path::String = tempname();  name = GPUCompiler.safe_nam
     isconcretetype(rt) || error("$f on $_tt did not infer to a concrete type. Got $rt")
 
     f_wrap!(out::Ref, args::Ref{<:Tuple}) = (out[] = f(args[]...); nothing)
-    @eval GPUCompiler.method_table(@nospecialize(job::GPUCompiler.CompilerJob{<:Any,StaticCompilerParams})) = nothing
-    @eval GPUCompiler.method_table(@nospecialize(job::GPUCompiler.CompilerJob{NativeCompilerTarget})) = nothing
-    @eval GPUCompiler.method_table(@nospecialize(job::GPUCompiler.CompilerJob{NativeCompilerTarget, StaticCompilerParams})) = nothing
-    _, _, table = generate_obj(f_wrap!, Tuple{RefValue{rt}, RefValue{tt}}, path, name; opt_level, strip_llvm, strip_asm, filename, ext = false, kwargs...)
-    @eval GPUCompiler.method_table(@nospecialize(job::GPUCompiler.CompilerJob{<:Any,StaticCompilerParams})) = method_table
-    @eval GPUCompiler.method_table(@nospecialize(job::GPUCompiler.CompilerJob{NativeCompilerTarget})) = method_table
-    @eval GPUCompiler.method_table(@nospecialize(job::GPUCompiler.CompilerJob{NativeCompilerTarget, StaticCompilerParams})) = method_table
+    _, _, table = generate_obj(f_wrap!, Tuple{RefValue{rt}, RefValue{tt}}, path, name; opt_level, strip_llvm, strip_asm, filename, kwargs...)
+
     lf = LazyStaticCompiledFunction{rt, tt}(Symbol(f), path, name, filename, table)
     cjl_path = joinpath(path, "$filename.cjl")
     serialize(cjl_path, lf)
@@ -114,41 +109,37 @@ end
 
 """
 ```julia
-(f, tt, path::String = tempname(), name = GPUCompiler.safe_name(repr(f)), filenamebase::String="obj";
+generate_obj(f, tt, path::String = tempname(), name = GPUCompiler.safe_name(repr(f)), filenamebase::String="obj";
             \tstrip_llvm = false,
             \tstrip_asm  = true,
-            \topt_level=3,
+            \topt_level = 3,
             \tkwargs...)
 ```
 Low level interface for compiling object code (`.o`) for for function `f` given
 a tuple type `tt` characterizing the types of the arguments for which the
 function will be compiled.
-
 ### Examples
 ```julia
 julia> fib(n) = n <= 1 ? n : fib(n - 1) + fib(n - 2)
 fib (generic function with 1 method)
-
 julia> path, name, table = StaticCompiler.generate_obj(fib, Tuple{Int64}, "./test")
 ("./test", "fib", IdDict{Any, String}())
-
 shell> tree \$path
 ./test
 └── obj.o
-
 0 directories, 1 file
 ```
 """
 function generate_obj(f, tt, path::String = tempname(), name = GPUCompiler.safe_name(repr(f)), filenamebase::String="obj";
                         strip_llvm = false,
                         strip_asm  = true,
-                        opt_level=3,
-                        ext = true,
+                        libjulia = true,
+                        opt_level = 3,
                         kwargs...)
     mkpath(path)
     obj_path = joinpath(path, "$filenamebase.o")
-    job, kwargs = native_job(f, tt; name,ext = ext, kwargs...)
-    tm = GPUCompiler.llvm_machine(job.target)
+    tm = GPUCompiler.llvm_machine(libjulia ? NativeCompilerTarget() : ExternalNativeCompilerTarget())
+    job, kwargs = native_job(f, tt; name, libjulia, kwargs...)
     #Get LLVM to generated a module of code for us. We don't want GPUCompiler's optimization passes.
     mod, meta = GPUCompiler.JuliaContext() do context
         GPUCompiler.codegen(:llvm, job; strip=strip_llvm, only_entry=false, validate=false, optimize=false, ctx=context)
@@ -179,92 +170,14 @@ end
 
 """
 ```julia
-compile_executable(f, types::Tuple, path::String, name::String=repr(f); filename::String=name, kwargs...)
-```
-Attempt to compile a standalone executable that runs function `f` with a type signature given by the tuple of `types`.
-
-### Examples
-```julia
-julia> using StaticCompiler
-
-julia> function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates.
-           # Note, this `llvmcall` requires Julia 1.8+
-           Base.llvmcall((\"""
-           ; External declaration of the puts function
-           declare i32 @puts(i8* nocapture) nounwind
-
-           define i32 @main(i8*) {
-           entry:
-               %call = call i32 (i8*) @puts(i8* %0)
-               ret i32 0
-           }
-           \""", "main"), Int32, Tuple{Ptr{UInt8}}, s)
-       end
-puts (generic function with 1 method)
-
-julia> function print_args(argc::Int, argv::Ptr{Ptr{UInt8}})
-           for i=1:argc
-               # Get pointer
-               p = unsafe_load(argv, i)
-               # Print string at pointer location (which fortunately already exists isn't tracked by the GC)
-               puts(p)
-           end
-           return 0
-       end
-
-julia> compile_executable(print_args, (Int, Ptr{Ptr{UInt8}}))
-"/Users/foo/code/StaticCompiler.jl/print_args"
-
-shell> ./print_args 1 2 3 4 Five
-./print_args
-1
-2
-3
-4
-Five
-```
-```julia
-julia> using StaticTools # So you don't have to define `puts` and friends every time
-
-julia> hello() = println(c"Hello, world!") # c"..." makes a stack-allocated StaticString
-
-julia> compile_executable(hello)
-"/Users/foo/code/StaticCompiler.jl/hello"
-
-shell> ./hello
-Hello, world!
-```
-"""
-function compile_executable(f, types=(), path::String="./", name=GPUCompiler.safe_name(repr(f));
-        filename=name,
-        cflags=``,
-        kwargs...
-    )
-
-    tt = Base.to_tuple_type(types)
-    # tt == Tuple{} || tt == Tuple{Int, Ptr{Ptr{UInt8}}} || error("input type signature $types must be either () or (Int, Ptr{Ptr{UInt8}})")
-
-    rt = only(native_code_typed(f, tt))[2]
-    isconcretetype(rt) || error("$f$types did not infer to a concrete type. Got $rt")
-
-    # Would be nice to use a compiler pass or something to check if there are any heap allocations or references to globals
-    # Keep an eye on https://github.com/JuliaLang/julia/pull/43747 for this
-
-    generate_executable(f, tt, path, name, filename; cflags=cflags, kwargs...)
-
-    joinpath(abspath(path), filename)
-end
-
-
-"""
-```julia
 compile_shlib(f, types::Tuple, path::String, name::String=repr(f); filename::String=name, kwargs...)
 ```
 As `compile_executable`, but compiling to a standalone `.dylib`/`.so` shared library.
 """
-function compile_shlib(f, types=(), path::String="./", name=GPUCompiler.safe_name(repr(f));
-        filename=name,
-        cflags=``,
+function compile_shlib(f::Function, types=(), path::String="./", name=GPUCompiler.safe_name(repr(f));
+        filename = name,
+        libjulia = false,
+        cflags = ``,
         kwargs...
     )
 
@@ -276,16 +189,17 @@ function compile_shlib(f, types=(), path::String="./", name=GPUCompiler.safe_nam
 
     # Would be nice to use a compiler pass or something to check if there are any heap allocations or references to globals
     # Keep an eye on https://github.com/JuliaLang/julia/pull/43747 for this
-    generate_shlib(f, tt, path, name, filename; cflags=cflags, kwargs...)
+    generate_shlib(f, tt, path, name, filename; libjulia, cflags, kwargs...)
 
     joinpath(abspath(path), filename * "." * Libdl.dlext)
 end
 
 function generate_shlib_fptr(f, tt, path::String=tempname(), name = GPUCompiler.safe_name(repr(f)), filename::String=name;
                             temp::Bool=true,
+                            libjulia=true,
                             kwargs...)
 
-    generate_shlib(f, tt, path, name; kwargs...)
+    generate_shlib(f, tt, path, name; libjulia, kwargs...)
     lib_path = joinpath(abspath(path), "$filename.$(Libdl.dlext)")
     ptr = Libdl.dlopen(lib_path, Libdl.RTLD_LOCAL)
     fptr = Libdl.dlsym(ptr, "julia_$name")
@@ -342,66 +256,6 @@ end
 
 """
 ```julia
-generate_executable(f, tt, path::String, name, filename=string(name); kwargs...)
-```
-Attempt to compile a standalone executable that runs `f`.
-
-### Examples
-```julia
-julia> function test(n)
-           r = 0.0
-           for i=1:n
-               r += log(sqrt(i))
-           end
-           return r/n
-       end
-test (generic function with 1 method)
-
-julia> path, name = StaticCompiler.generate_executable(test, Tuple{Int64}, "./scratch")
-```
-"""
-function generate_executable(f, tt, path=tempname(), name=GPUCompiler.safe_name(repr(f)), filename=string(name);
-        cflags=``,
-        kwargs...
-    )
-    mkpath(path)
-    obj_path = joinpath(path, "$filename.o")
-    exec_path = joinpath(path, filename)
-    job, kwargs = native_job(f, tt; name, kwargs...)
-    obj, _ = GPUCompiler.codegen(:obj, job; strip=true, only_entry=false, validate=false)
-
-    # Write to file
-    open(obj_path, "w") do io
-        write(io, obj)
-    end
-
-    # Pick a compiler
-    cc = Sys.isapple() ? `cc` : clang()
-    # Compile!
-    if Sys.isapple()
-        # Apple no longer uses _start, so we can just specify a custom entry
-        entry = "_julia_$name"
-        run(`$cc -e $entry $cflags $obj_path -o $exec_path`)
-    else
-        # Write a minimal wrapper to avoid having to specify a custom entry
-        wrapper_path = joinpath(path, "wrapper.c")
-        f = open(wrapper_path, "w")
-        print(f, """int main(int argc, char** argv)
-        {
-            julia_$name(argc, argv);
-            return 0;
-        }""")
-        close(f)
-        run(`$cc $wrapper_path $cflags $obj_path -o $exec_path`)
-        # Clean up
-        run(`rm $wrapper_path`)
-    end
-
-    path, name
-end
-
-"""
-```julia
 generate_shlib(f, tt, path::String, name::String, filenamebase::String="obj"; kwargs...)
 ```
 Low level interface for compiling a shared object / dynamically loaded library
@@ -432,14 +286,15 @@ julia> ccall(StaticCompiler.generate_shlib_fptr(path, name), Float64, (Int64,), 
 ```
 """
 function generate_shlib(f, tt, path=tempname(), name=GPUCompiler.safe_name(repr(f)), filename=name;
-        cflags=``,
+        libjulia = false,
+        cflags = ``,
         kwargs...
     )
 
     mkpath(path)
     obj_path = joinpath(path, "$filename.o")
     lib_path = joinpath(path, "$filename.$(Libdl.dlext)")
-    job, kwargs = native_job(f, tt; name, kwargs...)
+    job, kwargs = native_job(f, tt; name, libjulia, kwargs...)
     obj, _ = GPUCompiler.codegen(:obj, job; strip=true, only_entry=false, validate=false)
 
     open(obj_path, "w") do io
@@ -480,12 +335,12 @@ end
 
 #Return an LLVM module for multiple functions
 function native_llvm_module(funcs::Array; demangle = false, kwargs...)
-    f,tt = funcs[1]
-    mod = native_llvm_module(f,tt, kwargs...)
+    f,tt = first(funcs)
+    mod = native_llvm_module(f,tt; kwargs...)
     if length(funcs) > 1
         for func in funcs[2:end]
             @show f,tt = func
-            tmod = native_llvm_module(f,tt, kwargs...)
+            tmod = native_llvm_module(f,tt; kwargs...)
             link!(mod,tmod)
         end
     end
@@ -504,47 +359,15 @@ function native_llvm_module(funcs::Array; demangle = false, kwargs...)
     return mod
 end
 
-function generate_obj(funcs::Array, path::String = tempname(), filenamebase::String="obj";
-                        demangle =false,
-                        strip_llvm = false,
-                        strip_asm  = true,
-                        opt_level=3,
-                        ext = true,
-                        kwargs...)
-    f,tt = funcs[1]
-    mkpath(path)
-    obj_path = joinpath(path, "$filenamebase.o")
-    fakejob, kwargs = native_job(f,tt, ext = true, kwargs...)
-    mod = native_llvm_module(funcs; demangle = demangle, kwargs...)
-    obj, _ = GPUCompiler.emit_asm(fakejob, mod; strip=strip_asm, validate=false, format=LLVM.API.LLVMObjectFile)
-    open(obj_path, "w") do io
-        write(io, obj)
-    end
-    path, obj_path
-end
+## -- compile_shlib / generate_shlib / generate_obj, but for multiple functions at once
 
-function generate_shlib(funcs::Array, path::String = tempname(), filename::String="libfoo";
-        demangle=false,
-        cflags=``,
+function compile_shlib(funcs::Vector{<:Tuple}, path::String="./";
+        filename = "libfoo",
+        demangle = false,
+        libjulia = false,
+        cflags = ``,
         kwargs...
     )
-
-    lib_path = joinpath(path, "$filename.$(Libdl.dlext)")
-
-    _,obj_path = generate_obj(funcs, path, filename; demangle=demangle, kwargs...)
-    # Pick a Clang
-    cc = Sys.isapple() ? `cc` : clang()
-    # Compile!
-    run(`$cc -shared $cflags $obj_path -o $lib_path `)
-
-    path, name
-end
-
-function compile_shlib(funcs::Array, path::String="./";
-    filename="libfoo",
-    demangle=false,
-    cflags=``,
-    kwargs...)
     for func in funcs
         f, types = func
         tt = Base.to_tuple_type(types)
@@ -554,13 +377,199 @@ function compile_shlib(funcs::Array, path::String="./";
         isconcretetype(rt) || error("$f$types did not infer to a concrete type. Got $rt")
     end
 
-# Would be nice to use a compiler pass or something to check if there are any heap allocations or references to globals
-# Keep an eye on https://github.com/JuliaLang/julia/pull/43747 for this
-
-    generate_shlib(funcs, path, filename; demangle=demangle, cflags=cflags, kwargs...)
+    funcs_tt = [(first(f), Base.to_tuple_type(last(f))) for f in funcs]
+    generate_shlib(funcs_tt, path, filename; demangle, libjulia, cflags, kwargs...)
 
     joinpath(abspath(path), filename * "." * Libdl.dlext)
 end
 
+function generate_shlib(funcs::Vector{<:Tuple}, path::String = tempname(), filename::String="libfoo";
+        demangle = false,
+        libjulia = false,
+        cflags = ``,
+        kwargs...
+    )
+
+    lib_path = joinpath(path, "$filename.$(Libdl.dlext)")
+
+    _,obj_path = generate_obj(funcs, path, filename; demangle, libjulia, kwargs...)
+    # Pick a Clang
+    cc = Sys.isapple() ? `cc` : clang()
+    # Compile!
+    run(`$cc -shared $cflags $obj_path -o $lib_path `)
+
+    path, name
+end
+
+function generate_obj(funcs::Vector{<:Tuple}, path::String = tempname(), filenamebase::String="obj";
+                        demangle = false,
+                        libjulia = false,
+                        strip_llvm = false,
+                        strip_asm = true,
+                        opt_level = 3,
+                        kwargs...)
+    f,tt = first(funcs)
+    mkpath(path)
+    obj_path = joinpath(path, "$filenamebase.o")
+    fakejob, kwargs = native_job(f, tt; libjulia, kwargs...)
+    mod = native_llvm_module(funcs; demangle, libjulia, kwargs...)
+    obj, _ = GPUCompiler.emit_asm(fakejob, mod; strip=strip_asm, validate=false, format=LLVM.API.LLVMObjectFile)
+    open(obj_path, "w") do io
+        write(io, obj)
+    end
+    path, obj_path
+end
+
+## --- Compile standalone binaries
+
+"""
+```julia
+function compile_executable(f, types=(), path::String="./", name=GPUCompiler.safe_name(repr(f));
+        filename = name,
+        libjulia = false,
+        cflags = ``,
+        kwargs...
+    )
+```
+Attempt to compile a standalone executable that runs function `f` with a type signature given by the tuple of `types`.
+
+### Examples
+```julia
+julia> using StaticCompiler
+
+julia> function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates.
+           # Note, this `llvmcall` requires Julia 1.8+
+           Base.llvmcall((\"""
+           ; External declaration of the puts function
+           declare i32 @puts(i8* nocapture) nounwind
+
+           define i32 @main(i8*) {
+           entry:
+               %call = call i32 (i8*) @puts(i8* %0)
+               ret i32 0
+           }
+           \""", "main"), Int32, Tuple{Ptr{UInt8}}, s)
+       end
+puts (generic function with 1 method)
+
+julia> function print_args(argc::Int, argv::Ptr{Ptr{UInt8}})
+           for i=1:argc
+               # Get pointer
+               p = unsafe_load(argv, i)
+               # Print string at pointer location (which fortunately already exists isn't tracked by the GC)
+               puts(p)
+           end
+           return 0
+       end
+
+julia> compile_executable(print_args, (Int, Ptr{Ptr{UInt8}}))
+"/Users/foo/code/StaticCompiler.jl/print_args"
+
+shell> ./print_args 1 2 3 4 Five
+./print_args
+1
+2
+3
+4
+Five
+```
+```julia
+julia> using StaticTools # So you don't have to define `puts` and friends every time
+
+julia> hello() = println(c"Hello, world!") # c"..." makes a stack-allocated StaticString
+
+julia> compile_executable(hello)
+"/Users/foo/code/StaticCompiler.jl/hello"
+
+shell> ./hello
+Hello, world!
+```
+"""
+function compile_executable(f, types=(), path::String="./", name=GPUCompiler.safe_name(repr(f));
+        filename = name,
+        libjulia = false,
+        cflags = ``,
+        kwargs...
+    )
+
+    tt = Base.to_tuple_type(types)
+    # tt == Tuple{} || tt == Tuple{Int, Ptr{Ptr{UInt8}}} || error("input type signature $types must be either () or (Int, Ptr{Ptr{UInt8}})")
+
+    rt = only(native_code_typed(f, tt))[2]
+    isconcretetype(rt) || error("$f$types did not infer to a concrete type. Got $rt")
+
+    # Would be nice to use a compiler pass or something to check if there are any heap allocations or references to globals
+    # Keep an eye on https://github.com/JuliaLang/julia/pull/43747 for this
+
+    generate_executable(f, tt, path, name, filename; libjulia, cflags, kwargs...)
+
+    joinpath(abspath(path), filename)
+end
+
+
+"""
+```julia
+function generate_executable(f, tt, path=tempname(), name=GPUCompiler.safe_name(repr(f)), filename=string(name);
+        cflags = ``,
+        libjulia = false,
+        kwargs...
+    )
+```
+Attempt to compile a standalone executable that runs `f`.
+
+### Examples
+```julia
+julia> function test(n)
+           r = 0.0
+           for i=1:n
+               r += log(sqrt(i))
+           end
+           return r/n
+       end
+test (generic function with 1 method)
+
+julia> path, name = StaticCompiler.generate_executable(test, Tuple{Int64}, "./scratch")
+```
+"""
+function generate_executable(f, tt, path=tempname(), name=GPUCompiler.safe_name(repr(f)), filename=string(name);
+        cflags = ``,
+        libjulia = false,
+        kwargs...
+    )
+    mkpath(path)
+    obj_path = joinpath(path, "$filename.o")
+    exec_path = joinpath(path, filename)
+    job, kwargs = native_job(f, tt; name, libjulia, kwargs...)
+    obj, _ = GPUCompiler.codegen(:obj, job; strip=true, only_entry=false, validate=false)
+
+    # Write to file
+    open(obj_path, "w") do io
+        write(io, obj)
+    end
+
+    # Pick a compiler
+    cc = Sys.isapple() ? `cc` : clang()
+    # Compile!
+    if Sys.isapple()
+        # Apple no longer uses _start, so we can just specify a custom entry
+        entry = "_julia_$name"
+        run(`$cc -e $entry $cflags $obj_path -o $exec_path`)
+    else
+        # Write a minimal wrapper to avoid having to specify a custom entry
+        wrapper_path = joinpath(path, "wrapper.c")
+        f = open(wrapper_path, "w")
+        print(f, """int main(int argc, char** argv)
+        {
+            julia_$name(argc, argv);
+            return 0;
+        }""")
+        close(f)
+        run(`$cc $wrapper_path $cflags $obj_path -o $exec_path`)
+        # Clean up
+        run(`rm $wrapper_path`)
+    end
+
+    path, name
+end
 
 end # module

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -378,7 +378,8 @@ function generate_executable(f, tt, path=tempname(), name=GPUCompiler.safe_name(
         wrapper_path = joinpath(path, "wrapper.c")
         f = open(wrapper_path, "w")
         print(f, """int julia_$name(int argc, char** argv);
-        
+        void* __stack_chk_guard = (void*) $(rand(UInt) >> 1);
+
         int main(int argc, char** argv)
         {
             julia_$name(argc, argv);

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -377,7 +377,9 @@ function generate_executable(f, tt, path=tempname(), name=GPUCompiler.safe_name(
         # Write a minimal wrapper to avoid having to specify a custom entry
         wrapper_path = joinpath(path, "wrapper.c")
         f = open(wrapper_path, "w")
-        print(f, """int main(int argc, char** argv)
+        print(f, """int julia_$name(int argc, char** argv);
+        
+        int main(int argc, char** argv)
         {
             julia_$name(argc, argv);
             return 0;

--- a/test/scripts/interop.jl
+++ b/test/scripts/interop.jl
@@ -1,0 +1,16 @@
+using StaticCompiler
+using StaticTools
+
+function interop(argc, argv)
+    lib = StaticTools.dlopen(c"libm")
+    printf(lib)
+    sin = StaticTools.dlsym(lib, c"sin")
+    printf(sin)
+    x = @ptrcall sin(5.0::Float64)::Float64
+    printf(x)
+    newline()
+    StaticTools.dlclose(lib)
+end
+
+# Attempt to compile
+path = compile_executable(interop, (Int64, Ptr{Ptr{UInt8}}), "./", cflags=`-ldl -lm`)

--- a/test/scripts/loopvec_matrix.jl
+++ b/test/scripts/loopvec_matrix.jl
@@ -15,8 +15,8 @@ end
 
 function loopvec_matrix(argc::Int, argv::Ptr{Ptr{UInt8}})
     argc == 3 || return printf(stderrp(), c"Incorrect number of command-line arguments\n")
-    rows = parse(Int64, argv, 2)            # First command-line argument
-    cols = parse(Int64, argv, 3)            # Second command-line argument
+    rows = argparse(Int64, argv, 2)            # First command-line argument
+    cols = argparse(Int64, argv, 3)            # Second command-line argument
 
     # LHS
     A = MallocArray{Float64}(undef, rows, cols)
@@ -41,9 +41,8 @@ function loopvec_matrix(argc::Int, argv::Ptr{Ptr{UInt8}})
     # Print to stdout
     printf(C)
     # Also print to file
-    fp = fopen(c"table.tsv",c"w")
-    printf(fp, C)
-    fclose(fp)
+    printdlm(c"table.tsv", C, '\t')
+    fwrite(c"table.b", C)
     # Clean up matrices
     free(A)
     free(B)

--- a/test/scripts/loopvec_matrix_stack.jl
+++ b/test/scripts/loopvec_matrix_stack.jl
@@ -1,0 +1,49 @@
+using StaticCompiler
+using StaticTools
+using LoopVectorization
+
+@inline function mul!(C::StackArray, A::StackArray, B::StackArray)
+    @turbo for n ∈ indices((C,B), 2), m ∈ indices((C,A), 1)
+        Cmn = zero(eltype(C))
+        for k ∈ indices((A,B), (2,1))
+            Cmn += A[m,k] * B[k,n]
+        end
+        C[m,n] = Cmn
+    end
+    return C
+end
+
+function loopvec_matrix_stack()
+    rows = 10
+    cols = 5
+
+    # LHS
+    A = StackArray{Float64}(undef, rows, cols)
+    @turbo for i ∈ axes(A, 1)
+        for j ∈ axes(A, 2)
+           A[i,j] = i*j
+        end
+    end
+
+    # RHS
+    B = StackArray{Float64}(undef, cols, rows)
+    @turbo for i ∈ axes(B, 1)
+        for j ∈ axes(B, 2)
+           B[i,j] = i*j
+        end
+    end
+
+    # # Matrix multiplication
+    C = StackArray{Float64}(undef, cols, cols)
+    mul!(C, B, A)
+
+    # Print to stdout
+    printf(C)
+    # Also print to file
+    fp = fopen(c"table.tsv",c"w")
+    printf(fp, C)
+    fclose(fp)
+end
+
+# Attempt to compile
+path = compile_executable(loopvec_matrix_stack, (), "./")

--- a/test/scripts/loopvec_product.jl
+++ b/test/scripts/loopvec_product.jl
@@ -4,8 +4,8 @@ using LoopVectorization
 
 function loopvec_product(argc::Int, argv::Ptr{Ptr{UInt8}})
     argc == 3 || return printf(stderrp(), c"Incorrect number of command-line arguments\n")
-    rows = parse(Int64, argv, 2)            # First command-line argument
-    cols = parse(Int64, argv, 3)            # Second command-line argument
+    rows = argparse(Int64, argv, 2)            # First command-line argument
+    cols = argparse(Int64, argv, 3)            # Second command-line argument
 
     s = 0
     @turbo for i=1:rows

--- a/test/scripts/randn_matrix.jl
+++ b/test/scripts/randn_matrix.jl
@@ -1,17 +1,16 @@
 using StaticCompiler
 using StaticTools
 
-function rand_matrix(argc::Int, argv::Ptr{Ptr{UInt8}})
+function randn_matrix(argc::Int, argv::Ptr{Ptr{UInt8}})
     argc == 3 || return printf(stderrp(), c"Incorrect number of command-line arguments\n")
     rows = argparse(Int64, argv, 2)            # First command-line argument
     cols = argparse(Int64, argv, 3)            # Second command-line argument
 
-    # Manually fil matrix
     M = MallocArray{Float64}(undef, rows, cols)
-    rng = static_rng()
+    rng = MarsagliaPolar(static_rng())
     @inbounds for i=1:rows
         for j=1:cols
-            M[i,j] = rand(rng)
+            M[i,j] = randn(rng)
         end
     end
     printf(M)
@@ -20,4 +19,4 @@ end
 
 # Attempt to compile
 # cflags=`-lm`: need to explicitly include libm math library on linux
-path = compile_executable(rand_matrix, (Int64, Ptr{Ptr{UInt8}}), "./", cflags=`-lm`)
+path = compile_executable(randn_matrix, (Int64, Ptr{Ptr{UInt8}}), "./", cflags=`-lm`)

--- a/test/scripts/times_table.jl
+++ b/test/scripts/times_table.jl
@@ -3,8 +3,8 @@ using StaticTools
 
 function times_table(argc::Int, argv::Ptr{Ptr{UInt8}})
     argc == 3 || return printf(stderrp(), c"Incorrect number of command-line arguments\n")
-    rows = parse(Int64, argv, 2)            # First command-line argument
-    cols = parse(Int64, argv, 3)            # Second command-line argument
+    rows = argparse(Int64, argv, 2)            # First command-line argument
+    cols = argparse(Int64, argv, 3)            # Second command-line argument
 
     M = MallocArray{Int64}(undef, rows, cols)
     @inbounds for i=1:rows
@@ -15,9 +15,8 @@ function times_table(argc::Int, argv::Ptr{Ptr{UInt8}})
     # Print to stdout
     printf(M)
     # Also print to file
-    fp = fopen(c"table.tsv",c"w")
-    printf(fp, M)
-    fclose(fp)
+    fwrite(c"table.b", M)
+    printdlm(c"table.tsv", M)
     # Clean up matrix
     free(M)
 end

--- a/test/scripts/withmallocarray.jl
+++ b/test/scripts/withmallocarray.jl
@@ -1,0 +1,31 @@
+using StaticCompiler
+using StaticTools
+
+function withmallocarray(argc::Int, argv::Ptr{Ptr{UInt8}})
+    argc == 3 || return printf(stderrp(), c"Incorrect number of command-line arguments\n")
+    rows = argparse(Int64, argv, 2)            # First command-line argument
+    cols = argparse(Int64, argv, 3)            # Second command-line argument
+
+    mzeros(rows, cols) do A
+        printf(A)
+    end
+    mones(Int, rows, cols) do A
+        printf(A)
+    end
+    mfill(3.141592, rows, cols) do A
+        printf(A)
+    end
+
+    # Random number generation
+    rng = MarsagliaPolar()
+    mrand(rng, rows, cols) do A
+        printf(A)
+    end
+    mrandn(rng, rows, cols) do A
+        printf(A)
+    end
+end
+
+# Attempt to compile
+# cflags=`-lm`: need to explicitly include libm math library on linux
+path = compile_executable(withmallocarray, (Int64, Ptr{Ptr{UInt8}}), "./", cflags=`-lm`)

--- a/test/testintegration.jl
+++ b/test/testintegration.jl
@@ -1,82 +1,278 @@
 
 @testset "Standalone Executable Integration" begin
-
+    # Setup
     testpath = pwd()
     scratch = tempdir()
     cd(scratch)
+    jlpath = joinpath(Sys.BINDIR, Base.julia_exename()) # Get path to julia executable
 
-    # --- Times table, file IO, mallocarray
+    ## --- Times table, file IO, mallocarray
+    let
+        # Attempt to compile
+        # We have to start a new Julia process to get around the fact that Pkg.test
+        # disables `@inbounds`, but ironically we can use `--compile=min` to make that
+        # faster.
+        status = -1
+        try
+            isfile("times_table") && rm("times_table")
+            status = run(`$jlpath --compile=min $testpath/scripts/times_table.jl`)
+        catch e
+            @warn "Could not compile $testpath/scripts/times_table.jl"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
 
-    # Compile...
-    # We have to start a new Julia process to get around the fact that Pkg.test
-    # disables `@inbounds`, but ironically we can use `--compile=min` to make that
-    # faster.
-    status = run(`julia --compile=min $testpath/scripts/times_table.jl`)
-    @test isa(status, Base.Process)
-    @test status.exitcode == 0
+        # Attempt to run
+        println("5x5 times table:")
+        status = -1
+        try
+            status = run(`./times_table 5 5`)
+        catch e
+            @warn "Could not run $(scratch)/times_table"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
+        # Test ascii output
+        @test parsedlm(Int, c"table.tsv", '\t') == (1:5)*(1:5)'
+        # Test binary output
+        @test fread!(szeros(Int, 5,5), c"table.b") == (1:5)*(1:5)'
+    end
 
-    # Attempt to run
-    println("5x5 times table:")
-    status = run(`./times_table 5 5`)
-    @test isa(status, Base.Process)
-    @test status.exitcode == 0
-    @test parsedlm(Int64, c"table.tsv", '\t') == (1:5)*(1:5)'
+    ## --- "withmallocarray"-type do-block pattern
+    let
+        # Compile...
+        status = -1
+        try
+            isfile("withmallocarray") && rm("withmallocarray")
+            status = run(`$jlpath --compile=min $testpath/scripts/withmallocarray.jl`)
+        catch e
+            @warn "Could not compile $testpath/scripts/withmallocarray.jl"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
 
-    # --- Random number generation
+        # Run...
+        println("3x3 malloc arrays via do-block syntax:")
+        status = -1
+        try
+            status = run(`./withmallocarray 3 3`)
+        catch e
+            @warn "Could not run $(scratch)/withmallocarray"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
+    end
 
-    # Compile...
-    status = run(`julia --compile=min $testpath/scripts/rand_matrix.jl`)
-    @test isa(status, Base.Process)
-    @test status.exitcode == 0
+    ## --- Random number generation
+    let
+        # Compile...
+        status = -1
+        try
+            isfile("rand_matrix") && rm("rand_matrix")
+            status = run(`$jlpath --compile=min $testpath/scripts/rand_matrix.jl`)
+        catch e
+            @warn "Could not compile $testpath/scripts/rand_matrix.jl"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
 
-    # Run...
-    println("5x5 random matrix:")
-    status = run(`./rand_matrix 5 5`)
-    @test isa(status, Base.Process)
-    @test status.exitcode == 0
+        # Run...
+        println("5x5 uniform random matrix:")
+        status = -1
+        try
+            status = run(`./rand_matrix 5 5`)
+        catch e
+            @warn "Could not run $(scratch)/rand_matrix"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
+    end
 
-    # --- Test LoopVectorization integration
+    let
+        # Compile...
+        status = -1
+        try
+            isfile("randn_matrix") && rm("randn_matrix")
+            status = run(`$jlpath --compile=min $testpath/scripts/randn_matrix.jl`)
+        catch e
+            @warn "Could not compile $testpath/scripts/randn_matrix.jl"
+            println(e)
+        end
+        @static if Sys.isbsd()
+            @test isa(status, Base.Process)
+            @test isa(status, Base.Process) && status.exitcode == 0
+        end
 
-@static if LoopVectorization.VectorizationBase.has_feature(Val{:x86_64_avx2})
-    # Compile...
-    status = run(`julia --compile=min $testpath/scripts/loopvec_product.jl`)
-    @test isa(status, Base.Process)
-    @test status.exitcode == 0
+        # Run...
+        println("5x5 Normal random matrix:")
+        status = -1
+        try
+            status = run(`./randn_matrix 5 5`)
+        catch e
+            @warn "Could not run $(scratch)/randn_matrix"
+            println(e)
+        end
+        @static if Sys.isbsd()
+            @test isa(status, Base.Process)
+            @test isa(status, Base.Process) && status.exitcode == 0
+        end
+    end
 
-    # Run...
-    println("10x10 table sum:")
-    status = run(`./loopvec_product 10 10`)
-    @test isa(status, Base.Process)
-    @test status.exitcode == 0
-    @test parsedlm(c"product.tsv",'\t')[] == 3025
-end
+    ## --- Test LoopVectorization integration
+    @static if LoopVectorization.VectorizationBase.has_feature(Val{:x86_64_avx2})
+        let
+            # Compile...
+            status = -1
+            try
+                isfile("loopvec_product") && rm("loopvec_product")
+                status = run(`$jlpath --compile=min $testpath/scripts/loopvec_product.jl`)
+            catch e
+                @warn "Could not compile $testpath/scripts/loopvec_product.jl"
+                println(e)
+            end
+            @test isa(status, Base.Process)
+            @test isa(status, Base.Process) && status.exitcode == 0
 
-    # Compile...
-    status = run(`julia --compile=min $testpath/scripts/loopvec_matrix.jl`)
-    @test isa(status, Base.Process)
-    @test status.exitcode == 0
+            # Run...
+            println("10x10 table sum:")
+            status = -1
+            try
+                status = run(`./loopvec_product 10 10`)
+            catch e
+                @warn "Could not run $(scratch)/loopvec_product"
+                println(e)
+            end
+            @test isa(status, Base.Process)
+            @test isa(status, Base.Process) && status.exitcode == 0
+            @test parsedlm(c"product.tsv",'\t')[] == 3025
+        end
+    end
 
-    # Run...
-    println("10x3 matrix product:")
-    status = run(`./loopvec_matrix 10 3`)
-    @test isa(status, Base.Process)
-    @test status.exitcode == 0
-    A = (1:10) * (1:3)'
-    @test parsedlm(c"table.tsv",'\t') == A' * A
+    let
+        # Compile...
+        status = -1
+        try
+            isfile("loopvec_matrix") && rm("loopvec_matrix")
+            status = run(`$jlpath --compile=min $testpath/scripts/loopvec_matrix.jl`)
+        catch e
+            @warn "Could not compile $testpath/scripts/loopvec_matrix.jl"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
 
-    # --- Test string handling
+        # Run...
+        println("10x5 matrix product:")
+        status = -1
+        try
+            status = run(`./loopvec_matrix 10 5`)
+        catch e
+            @warn "Could not run $(scratch)/loopvec_matrix"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
+        A = (1:10) * (1:5)'
+        # Check ascii output
+        @test parsedlm(c"table.tsv",'\t') == A' * A
+        # Check binary output
+        @test fread!(szeros(5,5), c"table.b") == A' * A
+    end
 
-    # Compile...
-    status = run(`julia --compile=min $testpath/scripts/print_args.jl`)
-    @test isa(status, Base.Process)
-    @test status.exitcode == 0
+    let
+        # Compile...
+        status = -1
+        try
+            isfile("loopvec_matrix_stack") && rm("loopvec_matrix_stack")
+            status = run(`$jlpath --compile=min $testpath/scripts/loopvec_matrix_stack.jl`)
+        catch e
+            @warn "Could not compile $testpath/scripts/loopvec_matrix_stack.jl"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
 
-    # Run...
-    println("String indexing and handling:")
-    status = run(`./print_args foo bar`)
-    @test isa(status, Base.Process)
-    @test status.exitcode == 0
+        # Run...
+        println("10x5 matrix product:")
+        status = -1
+        try
+            status = run(`./loopvec_matrix_stack`)
+        catch e
+            @warn "Could not run $(scratch)/loopvec_matrix_stack"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
+        A = (1:10) * (1:5)'
+        @test parsedlm(c"table.tsv",'\t') == A' * A
+    end
 
-    # --- Clean up
+
+    ## --- Test string handling
+
+    let
+        # Compile...
+        status = -1
+        try
+            isfile("print_args") && rm("print_args")
+            status = run(`$jlpath --compile=min $testpath/scripts/print_args.jl`)
+        catch e
+            @warn "Could not compile $testpath/scripts/print_args.jl"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
+
+        # Run...
+        println("String indexing and handling:")
+        status = -1
+        try
+            status = run(`./print_args foo bar`)
+        catch e
+            @warn "Could not run $(scratch)/print_args"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
+    end
+
+    ## --- Test interop
+
+    @static if Sys.isbsd()
+    let
+        # Compile...
+        status = -1
+        try
+            isfile("interop") && rm("interop")
+            status = run(`$jlpath --compile=min $testpath/scripts/interop.jl`)
+        catch e
+            @warn "Could not compile $testpath/scripts/interop.jl"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
+
+        # Run...
+        println("Interop:")
+        status = -1
+        try
+            status = run(`./interop`)
+        catch e
+            @warn "Could not run $(scratch)/interop"
+            println(e)
+        end
+        @test isa(status, Base.Process)
+        @test isa(status, Base.Process) && status.exitcode == 0
+    end
+    end
+
+    ## --- Clean up
+
     cd(testpath)
 end


### PR DESCRIPTION
This makes more of the tests pass -- should be fine re: Mason's interface now AFAICT.

Now it seems there's just an issue where something added here is causing some dynamic dispatch (`_ijl_apply_generic `) and some allocations (`_gpu_gc_pool_alloc`) that didn't used to be there in the integration tests when we go to actually compile things